### PR TITLE
Chapter 3: Updated zig build-exe to include file name

### DIFF
--- a/chapter-3.md
+++ b/chapter-3.md
@@ -29,7 +29,7 @@ Some common arguments:
 - `--strip`, which removes debug info from the binary.
 - `--dynamic`, which is used in conjunction with `zig build-lib` to output a dynamic/shared library.
 
-Let's create a tiny hello world. Save this as `tiny-hello.zig`, and run `zig build-exe -O ReleaseSmall --strip --single-threaded`. Currently for `x86_64-windows`, this produces a 2.5KiB executable.
+Let's create a tiny hello world. Save this as `tiny-hello.zig`, and run `zig build-exe .\tiny-hello.zig -O ReleaseSmall --strip --single-threaded`. Currently for `x86_64-windows`, this produces a 2.5KiB executable.
 
 <!--no_test-->
 ```zig


### PR DESCRIPTION
Currently in [Chapter 3: Outputting an Executable](https://github.com/sobeston/ziglearn/blob/master/chapter-3.md#outputting-an-executable)

For the following zig build command 

```
zig build-exe -O ReleaseSmall --strip --single-threaded
```

It fails with 

```
error: --name [name] not provided and unable to infer
```

To fix this, similar to [Chapter 3: Cross compilation](https://github.com/Sobeston/ziglearn/blob/master/chapter-3.md#cross-compilation) adding the file name makes the build happen successfully.

```
zig build-exe .\tiny-hello.zig -O ReleaseSmall --strip --single-threaded
```