### PR TITLE
Chapter 2: fix broken link to std.mem.sort

### DIFF
--- a/chapter-2.md
+++ b/chapter-2.md
@@ -707,7 +707,7 @@ test "sorting" {
 
 [`std.sort.asc`](https://ziglang.org/documentation/master/std/#A;std:sort.asc) and [`.desc`](https://ziglang.org/documentation/master/std/#A;std:sort.desc) create a comparison function for the given type at comptime; if non-numerical types should be sorted, the user must provide their own comparison function.
 
-[`std.sort.sort`](https://ziglang.org/documentation/master/std/#A;std:sort.sort) has a best case of O(n), and an average and worst case of O(n*log(n)).
+[`std.mem.sort`](https://ziglang.org/documentation/master/std/#A;std:mem.sort) has a best case of O(n), and an average and worst case of O(n*log(n)).
 
 # Iterators
 


### PR DESCRIPTION
Fix broken link std.sort.sort to std.mem.sort, which is used in the example test.