### PR TITLE
Update to prng.random()

### DIFF
--- a/website/blog/a-guessing-game.md
+++ b/website/blog/a-guessing-game.md
@@ -23,7 +23,7 @@ Let's initialise *std.rand.DefaultPrng* with a 64 bit unsigned integer (`u64`). 
 
 ```zig
     var prng = std.rand.DefaultPrng.init(1625953);
-    const rand = &prng.random;
+    const rand = prng.random();
 
     try stdout.print(
         "not-so random number: {}\n",


### PR DESCRIPTION
Fixes the compiler error: 

error: no field named 'random' in struct 'rand.Xoshiro256'

Tested working on zig version: 0.12.0-dev