### PR TITLE
Fix case typo 'Arraylist' to 'ArrayList'

### DIFF
--- a/website/docs/02-standard-library/02-arraylist.mdx
+++ b/website/docs/02-standard-library/02-arraylist.mdx
@@ -2,7 +2,7 @@ import CodeBlock from "@theme/CodeBlock";
 
 import ArrayList from "!!raw-loader!./02.arraylist.zig";
 
-# Arraylist
+# ArrayList
 
 The
 [`std.ArrayList`](https://ziglang.org/documentation/master/std/#A;std:ArrayList)


### PR DESCRIPTION
I assume the lowercase 'L' in the 'Arraylist' header was a mistake