### PR TITLE
Update 03.filesystem-make-dir-iterable.zig

### DIFF
--- a/website/docs/02-standard-library/03.filesystem-make-dir-iterable.zig
+++ b/website/docs/02-standard-library/03.filesystem-make-dir-iterable.zig
@@ -5,18 +5,18 @@ const eql = std.mem.eql;
 // hide-end
 test "make dir" {
     try std.fs.cwd().makeDir("test-tmp");
-    var iter_dir = try std.fs.cwd().openIterableDir(
+    var iter_dir = try std.fs.cwd().openDir(
         "test-tmp",
-        .{},
+        .{ .iterate = true },
     );
     defer {
         iter_dir.close();
         std.fs.cwd().deleteTree("test-tmp") catch unreachable;
     }
 
-    _ = try iter_dir.dir.createFile("x", .{});
-    _ = try iter_dir.dir.createFile("y", .{});
-    _ = try iter_dir.dir.createFile("z", .{});
+    _ = try iter_dir.createFile("x", .{});
+    _ = try iter_dir.createFile("y", .{});
+    _ = try iter_dir.createFile("z", .{});
 
     var file_count: usize = 0;
     var iter = iter_dir.iterate();


### PR DESCRIPTION
cwd() no longer has method openIterableDir, instead that is handled by passing .iterate = True as a parameter to the openDir, in addition the resulting object is a plain dir, so calls should be to createFile, not .dirCreateFile.