### PR TITLE
Update 10-runtime-safety.mdx and 11-pointers.mdx

### DIFF
--- a/website/docs/01-language-basics/10-runtime-safety.mdx
+++ b/website/docs/01-language-basics/10-runtime-safety.mdx
@@ -75,17 +75,4 @@ test "unreachable"...reached unreachable code
 
 Here is an unreachable being used in a switch.
 
-```zig
-fn asciiToUpper(x: u8) u8 {
-    return switch (x) {
-        'a'...'z' => x + 'A' - 'a',
-        'A'...'Z' => x,
-        else => unreachable,
-    };
-}
-
-test "unreachable switch" {
-    try expect(asciiToUpper('a') == 'A');
-    try expect(asciiToUpper('A') == 'A');
-}
-```
+<CodeBlock language="zig">{SwitchUnreachable}</CodeBlock>

--- a/website/docs/01-language-basics/11-pointers.mdx
+++ b/website/docs/01-language-basics/11-pointers.mdx
@@ -10,17 +10,7 @@ Normal pointers in Zig cannot have 0 or null as a value. They follow the syntax
 Referencing is done with `&variable`, and dereferencing is done with
 `variable.*`.
 
-```zig
-fn increment(num: *u8) void {
-    num.* += 1;
-}
-
-test "pointers" {
-    var x: u8 = 1;
-    increment(&x);
-    try expect(x == 2);
-}
-```
+<CodeBlock language="zig">{Pointers}</CodeBlock>
 
 Trying to set a `*T` to the value 0 is detectable illegal behaviour.
 


### PR DESCRIPTION
Use CodeBlock to simplify code copying.