### PR TITLE
`gyro` is in public archive now

### DIFF
--- a/website/versioned_docs/version-0.11/03-build-system/07-modules.md
+++ b/website/versioned_docs/version-0.11/03-build-system/07-modules.md
@@ -81,8 +81,8 @@ Version Date
 
 Zig does not yet have an official package manager. Some unofficial experimental
 package managers however do exist, namely
-[gyro](https://github.com/mattnite/gyro). The `table-helper` package is
-designed to support both of them.
+[`zigmod`](https://github.com/nektro/zigmod). The `table-helper` package is
+designed to support it.
 
 Some good places to find packages include: [astrolabe.pm](https://astrolabe.pm),
 [zpm](https://zpm.random-projects.net/),

--- a/website/versioned_docs/version-0.11/03-build-system/07-modules.md
+++ b/website/versioned_docs/version-0.11/03-build-system/07-modules.md
@@ -81,8 +81,7 @@ Version Date
 
 Zig does not yet have an official package manager. Some unofficial experimental
 package managers however do exist, namely
-[gyro](https://github.com/mattnite/gyro) and
-[zigmod](https://github.com/nektro/zigmod). The `table-helper` package is
+[gyro](https://github.com/mattnite/gyro). The `table-helper` package is
 designed to support both of them.
 
 Some good places to find packages include: [astrolabe.pm](https://astrolabe.pm),


### PR DESCRIPTION
No longer maintained, apparently.