### PR TITLE
fix: For-loop syntax in fahrenheit-to-celsius post

### DIFF
--- a/website/blog/fahrenheit-to-celsius.md
+++ b/website/blog/fahrenheit-to-celsius.md
@@ -31,7 +31,7 @@ pub fn main() !void {
     const stdout = std.io.getStdOut().writer();
     const args = try std.process.argsAlloc(std.heap.page_allocator);
 
-    for (args) |arg, i| {
+    for (args, 0..) |arg, i| {
         try stdout.print("arg {}: {s}\n", .{ i, arg });
     }
 }
@@ -67,7 +67,7 @@ pub fn main() !void {
 
     if (args.len < 2) return error.ExpectedArgument;
 
-    for (args) |arg, i| {
+    for (args, 0..) |arg, i| {
         if (i == 0) continue;
         try stdout.print("arg {}: {s}\n", .{ i, arg });
     }


### PR DESCRIPTION
As explained on the for-loop guide in zig.guide here - https://zig.guide/language-basics/for-loops/,
To capture the index, we also need to initialize the variable for index with 0 using `0..` syntax. This PR fixes that syntax typo.