### PR TITLE
Update orelse typeof in optionals

### DIFF
--- a/website/versioned_docs/version-0.12/01-language-basics/23-optionals.md
+++ b/website/versioned_docs/version-0.12/01-language-basics/23-optionals.md
@@ -24,7 +24,7 @@ test "orelse" {
     var a: ?f32 = null;
     var b = a orelse 0;
     try expect(b == 0);
-    try expect(@TypeOf(b) == f32);
+    try expect(@TypeOf(b) == comptime_int);
 }
 ```
 

--- a/website/versioned_docs/version-0.12/01-language-basics/23-optionals.md
+++ b/website/versioned_docs/version-0.12/01-language-basics/23-optionals.md
@@ -24,7 +24,7 @@ test "orelse" {
     var a: ?f32 = null;
     var b = a orelse 0;
     try expect(b == 0);
-    try expect(@TypeOf(b) == comptime_int);
+    try expect(@TypeOf(b) == f32);
 }
 ```
 


### PR DESCRIPTION
I was going through the example code for the `orelse` section in the options and noticed a discrepancy on the line `try expect(@TypeOf(b) == f32);`. Upon inspection, I got that the type of `b` is `comptime_int`. 

Please let me know if this is incorrect. Or if something is missing.

![image](https://github.com/Sobeston/zig.guide/assets/26891820/8d7ec6b3-ccfc-49fc-83ae-902796ed338c)
