### PR TITLE
Add .zig-cache to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.zig-cache/
 zig-*/
 junk*
 test-out/


### PR DESCRIPTION
This is needed per this recent change: https://ziglang.org/download/0.13.0/release-notes.html#codezig-cachecode-renamed-to-codezig-cachecode