### PR TITLE
Local variable is never mutated

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/10-runtime-safety.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/10-runtime-safety.mdx
@@ -16,7 +16,7 @@ For example, runtime safety protects you from out of bounds indices.
 ```zig
 test "out of bounds" {
     const a = [3]u8{ 1, 2, 3 };
-    var index: u8 = 5;
+    const index: u8 = 5;
     const b = a[index];
     _ = b;
 }
@@ -37,7 +37,7 @@ function
 test "out of bounds, no safety" {
     @setRuntimeSafety(false);
     const a = [3]u8{ 1, 2, 3 };
-    var index: u8 = 5;
+    const index: u8 = 5;
     const b = a[index];
     _ = b;
 }


### PR DESCRIPTION
Changed var index to const index: Since local variable is never muted

test "out of bounds" {
    const a = [3]u8{ 1, 2, 3 };
    const index: u8 = 5;
    const b = a[index];
    _ = b;
}


test "out of bounds, no safety" {
    @setRuntimeSafety(false);
    const a = [3]u8{ 1, 2, 3 };
    const index: u8 = 5;
    const b = a[index];
    _ = b;
}


![image](https://github.com/Sobeston/zig.guide/assets/101001298/1096bc90-19d6-4242-973a-146c91e9c4a8)
