### PR TITLE
local variable is never mutated

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/10-runtime-safety.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/10-runtime-safety.mdx
@@ -16,7 +16,7 @@ For example, runtime safety protects you from out of bounds indices.
 ```zig
 test "out of bounds" {
     const a = [3]u8{ 1, 2, 3 };
-    var index: u8 = 5;
+    const index: u8 = 5;
     const b = a[index];
     _ = b;
 }
@@ -37,7 +37,7 @@ function
 test "out of bounds, no safety" {
     @setRuntimeSafety(false);
     const a = [3]u8{ 1, 2, 3 };
-    var index: u8 = 5;
+    const index: u8 = 5;
     const b = a[index];
     _ = b;
 }

--- a/website/versioned_docs/version-0.13/01-language-basics/17-unions.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/17-unions.mdx
@@ -12,9 +12,15 @@ unions cannot be used to reinterpret memory. Accessing a field in a union that
 is not active is detectable illegal behaviour.
 
 ```zig
+const Result = union {
+    int: i64,
+    float: f64,
+    bool: bool,
+};
+
 test "simple union" {
     var result = Result{ .int = 1234 };
-    result = Result{ .float = 12.34 }; 
+    result.float = Result{12.34 }; 
 ```
 
 ```

--- a/website/versioned_docs/version-0.13/01-language-basics/17-unions.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/17-unions.mdx
@@ -12,16 +12,9 @@ unions cannot be used to reinterpret memory. Accessing a field in a union that
 is not active is detectable illegal behaviour.
 
 ```zig
-const Result = union {
-    int: i64,
-    float: f64,
-    bool: bool,
-};
-
 test "simple union" {
     var result = Result{ .int = 1234 };
-    result.float = 12.34;
-}
+    result = Result{ .float = 12.34 }; 
 ```
 
 ```


### PR DESCRIPTION
Changed var index to const index: Since local variable is never mutated

test "out of bounds" {
    const a = [3]u8{ 1, 2, 3 };
    const index: u8 = 5;
    const b = a[index];
    _ = b;
}


test "out of bounds, no safety" {
    @setRuntimeSafety(false);
    const a = [3]u8{ 1, 2, 3 };
    const index: u8 = 5;
    const b = a[index];
    _ = b;
}