### PR TITLE
Update 13-iterators.md, openIterableDir not a method anymore.

### DIFF
--- a/website/versioned_docs/version-0.12/02-standard-library/13-iterators.md
+++ b/website/versioned_docs/version-0.12/02-standard-library/13-iterators.md
@@ -30,10 +30,8 @@ opened with iterate permissions for the directory iterator to work.
 
 ```zig
 test "iterator looping" {
-    var iter = (try std.fs.cwd().openIterableDir(
-        ".",
-        .{},
-    )).iterate();
+    var iter = (try std.fs.cwd().openDir(".", .{ .iterate = true })).iterate();
+
 
     var file_count: usize = 0;
     while (try iter.next()) |entry| {


### PR DESCRIPTION
std.fs.cwd().openIterableDir doesn't compile in zig 0.13.0.  Suggested an alternate code that compiles and returns an iterator over the directory.