### PR TITLE
Update 03-filesystem.mdx - introduce first use of auto-Enum scope

### DIFF
--- a/website/versioned_docs/version-0.12/02-standard-library/03-filesystem.mdx
+++ b/website/versioned_docs/version-0.12/02-standard-library/03-filesystem.mdx
@@ -20,6 +20,9 @@ We can get various information about files by using `.stat()` on them. `Stat`
 also contains fields for .inode and .mode, but they are not tested here as they
 rely on the current OS' types.
 
+When the Enum type is known from context, it can be omitted, so we can
+compare `stat.kind` to `.file` instead of `Kind.file`.
+
 <CodeBlock language="zig">{Stat}</CodeBlock>
 
 We can make directories and iterate over their contents. Here we will use an


### PR DESCRIPTION
This is the first time this feature is used in the guide, I believe, so explicitly introduce it.