### PR TITLE
Fix `TypeInfo` link and name on chapter 24 - comptime

### DIFF
--- a/website/versioned_docs/version-0.11/01-language-basics/24-comptime.md
+++ b/website/versioned_docs/version-0.11/01-language-basics/24-comptime.md
@@ -72,7 +72,7 @@ test "returning a type" {
 We can reflect upon types using the built-in
 [`@typeInfo`](https://ziglang.org/documentation/master/#typeInfo), which takes
 in a `type` and returns a tagged union. This tagged union type can be found in
-[`std.builtin.TypeInfo`](https://ziglang.org/documentation/master/std/#std;builtin.TypeInfo)
+[`std.builtin.Type`](https://ziglang.org/documentation/master/std/#std.builtin.Type)
 (info on how to make use of imports and std later).
 
 ```zig

--- a/website/versioned_docs/version-0.12/01-language-basics/24-comptime.mdx
+++ b/website/versioned_docs/version-0.12/01-language-basics/24-comptime.mdx
@@ -46,7 +46,7 @@ PascalCase, as it returns a type.
 We can reflect upon types using the built-in
 [`@typeInfo`](https://ziglang.org/documentation/master/#typeInfo), which takes
 in a `type` and returns a tagged union. This tagged union type can be found in
-[`std.builtin.TypeInfo`](https://ziglang.org/documentation/master/std/#std;builtin.TypeInfo)
+[`std.builtin.Type`](https://ziglang.org/documentation/master/std/#std.builtin.Type)
 (info on how to make use of imports and std later).
 
 <CodeBlock language="zig">{ComptimeTypeinfo}</CodeBlock>


### PR DESCRIPTION
The current text and link present on chapter 24 is trying to link to a dead link and a deprecated type. Specifically, https://ziglang.org/documentation/master/std/#std;builtin.TypeInfo. That type has been deprecated since ziglang/zig@48bec903c2ee423170a13cce41edc755e6468e37 in favor of [std.builtin.Type](https://ziglang.org/documentation/master/std/#std.builtin.Type)