### PR TITLE
Fix broken link

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/03-if.mdx
@@ -10,7 +10,7 @@ like C or Javascript, there are no values that implicitly coerce to bool values.
 
 Here, we will introduce testing. Save the below code and compile + run it with
 `zig test file-name.zig`. We will be using the
-[`expect`](https://ziglang.org/documentation/master/std/#std;testing.expect)
+[`expect`](https://ziglang.org/documentation/master/std/#std.testing.expect)
 function from the standard library, which will cause the test to fail if it's
 given the value `false`. When a test fails, the error and stack trace will be
 shown.


### PR DESCRIPTION
The current link yields a "Declaration not found" message.