### PR TITLE
Update 11-pointers.mdx

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
@@ -16,8 +16,8 @@ Trying to set a `*T` to the value 0 is detectable illegal behaviour.
 
 ```zig
 test "naughty pointer" {
-    var x: u16 = 0;
-    var y: *u8 = @ptrFromInt(x);
+    const x: u16 = 0;
+    const y: *u8 = @ptrFromInt(x);
     _ = y;
 }
 ```


### PR DESCRIPTION
Complier complains about not mutaded var, before the zero address complained.

file-name.zig:234:9: error: local variable is never mutated
    var y: *u8 = @ptrFromInt(x);
        ^
file-name.zig:234:9: note: consider using 'const'
file-name.zig:233:9: error: local variable is never mutated
    var x: u16 = 0;
        ^
file-name.zig:233:9: note: consider using 'const'