### PR TITLE
Update 30-vectors.mdx

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/30-vectors.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/30-vectors.mdx
@@ -40,18 +40,6 @@ multiply a vector by a scalar.
 Vectors do not have a `len` field like arrays, but may still be looped over.
 
 <CodeBlock language="zig">{VectorsLooping}</CodeBlock>
-```zig
-test "vector looping" {
-    const x = @Vector(4, u8){ 255, 0, 255, 0 };
-    var sum = blk: {
-        var tmp: u10 = 0;
-        var i: u8 = 0;
-        while (i < 4) : (i += 1) tmp += x[i];
-        break :blk tmp;
-    };
-    try expect(sum == 510);
-}
-```
 
 Vectors coerce to their respective arrays.
 


### PR DESCRIPTION
https://zig.guide/language-basics/vectors page contains two "vector looping" code snippets, they are almost the same.

The only difference is:
The first one has:
```zig
const sum = blk: {
```
the second has
```zig
var sum = blk: {
```

Variant with `var` considered as error actually, because variable does not change.

So my fix is removing the duplication.