### PR TITLE
Update 03.filesystem-cwd-create.zig

### DIFF
--- a/website/versioned_docs/version-0.13/02-standard-library/03.filesystem-cwd-create.zig
+++ b/website/versioned_docs/version-0.13/02-standard-library/03.filesystem-cwd-create.zig
@@ -10,8 +10,7 @@ test "createFile, write, seekTo, read" {
     );
     defer file.close();
 
-    const bytes_written = try file.writeAll("Hello File!");
-    _ = bytes_written;
+    try file.writeAll("Hello File!");
 
     var buffer: [100]u8 = undefined;
     try file.seekTo(0);


### PR DESCRIPTION
In the Filesystem guide https://zig.guide/standard-library/filesystem/ the first code snippet is not logically valid.

The line:
```zig
const bytes_written = try file.writeAll("Hello File!");
```
is not correct, because `file.writeAll` has return type of `WriteError!void`, so variable `bytes_written` is always `void` in this case.

`bytes_written` can be gotten if we replace `writeAll` by `write`, but I don't think we want to do that in this example.