### PR TITLE
rand to Random in 0.14 versioned docs

### DIFF
--- a/website/versioned_docs/version-0.14/02-standard-library/07-random-numbers.mdx
+++ b/website/versioned_docs/version-0.14/02-standard-library/07-random-numbers.mdx
@@ -8,7 +8,7 @@ import RandomNumbersCrypto from "!!raw-loader!./07.random-numbers-crypto.zig";
 Here, we create a new prng using a 64-bit random seed. a, b, c, and d are given
 random values via this prng. The expressions giving c and d values are
 equivalent. `DefaultPrng` is `Xoroshiro128`; there are other prngs available in
-std.rand.
+`std.Random`.
 
 <CodeBlock language="zig">{RandomNumbers}</CodeBlock>
 
@@ -17,6 +17,6 @@ Cryptographically secure random is also available.
 <CodeBlock language="zig">{RandomNumbersCrypto}</CodeBlock>
 
 :::info
-We can now use our knowledge of std.rand and [make a guessing game together](/posts/a-guessing-game).
+We can now use our knowledge of `std.Random` and [make a guessing game together](/posts/a-guessing-game).
 
 :::

--- a/website/versioned_docs/version-0.14/02-standard-library/07.random-numbers.zig
+++ b/website/versioned_docs/version-0.14/02-standard-library/07.random-numbers.zig
@@ -3,7 +3,7 @@ const std = @import("std");
 
 // hide-end
 test "random numbers" {
-    var prng = std.rand.DefaultPrng.init(blk: {
+    var prng = std.Random.DefaultPrng.init(blk: {
         var seed: u64 = undefined;
         try std.posix.getrandom(std.mem.asBytes(&seed));
         break :blk seed;


### PR DESCRIPTION
`rand` changed to `Random` as of https://github.com/ziglang/zig/pull/18867