### PR TITLE
01-if.mdx - add a hint that ternary operators don't exist in zig.

### DIFF
--- a/website/versioned_docs/version-0.11/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.11/01-language-basics/03-if.mdx
@@ -15,6 +15,8 @@ function from the standard library, which will cause the test to fail if it's
 given the value `false`. When a test fails, the error and stack trace will be
 shown.
 
+Ternary conditional operators (cond ? a : b) do not exist in zig.
+
 <CodeBlock language="zig">{Expect}</CodeBlock>
 
 If statements also work as expressions.

--- a/website/versioned_docs/version-0.12/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.12/01-language-basics/03-if.mdx
@@ -15,6 +15,8 @@ function from the standard library, which will cause the test to fail if it's
 given the value `false`. When a test fails, the error and stack trace will be
 shown.
 
+Ternary conditional operators (cond ? a : b) do not exist in zig.
+
 <CodeBlock language="zig">{Expect}</CodeBlock>
 
 If statements also work as expressions.

--- a/website/versioned_docs/version-0.13/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/03-if.mdx
@@ -15,6 +15,8 @@ function from the standard library, which will cause the test to fail if it's
 given the value `false`. When a test fails, the error and stack trace will be
 shown.
 
+Ternary conditional operators (cond ? a : b) do not exist in zig.
+
 <CodeBlock language="zig">{Expect}</CodeBlock>
 
 If statements also work as expressions.

--- a/website/versioned_docs/version-0.14/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.14/01-language-basics/03-if.mdx
@@ -15,6 +15,8 @@ function from the standard library, which will cause the test to fail if it's
 given the value `false`. When a test fails, the error and stack trace will be
 shown.
 
+Ternary conditional operators (cond ? a : b) do not exist in zig.
+
 <CodeBlock language="zig">{Expect}</CodeBlock>
 
 If statements also work as expressions.


### PR DESCRIPTION
Since there is no participation note about a local hot reloadable dev server I just expect that this is being displayed as one would expect it. Haven't used mdx before, more of a markdown guy :P 