### PR TITLE
Display correct version number (0.13.0) in 02-installation.mdx

### DIFF
--- a/website/versioned_docs/version-0.13/00-getting-started/02-installation.mdx
+++ b/website/versioned_docs/version-0.13/00-getting-started/02-installation.mdx
@@ -118,7 +118,7 @@ Verify your installation with `zig version`. The output should look like this:
 
 ```
 $ zig version
-0.12.0
+0.13.0
 ```
 
 ### Extras


### PR DESCRIPTION
Noticed docs for 0.13.0 still show 0.12.0 when running `zig version`