### PR TITLE
fix version number in getting-started/installation

### DIFF
--- a/website/versioned_docs/version-0.13/00-getting-started/02-installation.mdx
+++ b/website/versioned_docs/version-0.13/00-getting-started/02-installation.mdx
@@ -19,9 +19,9 @@ import TabItem from "@theme/TabItem";
 
     ### Installing manually
 
-    1. [Download](https://ziglang.org/download/#release-0.12.0) a prebuilt version of Zig.
+    1. [Download](https://ziglang.org/download/#release-0.13.0) a prebuilt version of Zig.
 
-        Choose a build of Zig 0.12 for Linux that matches your CPU architecture. If you're unsure which architecture you're using, this can be found with:
+        Choose a build of Zig 0.13 for Linux that matches your CPU architecture. If you're unsure which architecture you're using, this can be found with:
 
         ```bash
         uname -m
@@ -30,13 +30,13 @@ import TabItem from "@theme/TabItem";
     2. Extract the archive using tar, e.g.
 
         ```bash
-        tar xf zig-linux-x86_64-0.12.0.tar.xz
+        tar xf zig-linux-x86_64-0.13.0.tar.xz
         ```
 
     3. Add the location of your Zig binary to your path, e.g.
 
         ```bash
-        echo 'export PATH="$HOME/zig-linux-x86_64-0.12.0:$PATH"' >> ~/.bashrc
+        echo 'export PATH="$HOME/zig-linux-x86_64-0.13.0:$PATH"' >> ~/.bashrc
         ```
     </TabItem>
     <TabItem value="windows">
@@ -56,9 +56,9 @@ import TabItem from "@theme/TabItem";
 
     ### Installing manually
 
-    1. [Download](https://ziglang.org/download/#release-0.12.0) a prebuilt version of Zig.
+    1. [Download](https://ziglang.org/download/#release-0.13.0) a prebuilt version of Zig.
 
-        Choose a build of Zig 0.12 for Windows that matches your CPU architecture. Most Windows systems use `x86_64`, also known as `AMD64`. If you're unsure which architecture you're using, this can be found with:
+        Choose a build of Zig 0.13 for Windows that matches your CPU architecture. Most Windows systems use `x86_64`, also known as `AMD64`. If you're unsure which architecture you're using, this can be found with:
 
         ```powershell
         $Env:PROCESSOR_ARCHITECTURE
@@ -118,7 +118,7 @@ Verify your installation with `zig version`. The output should look like this:
 
 ```
 $ zig version
-0.12.0
+0.13.0
 ```
 
 ### Extras

--- a/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
+++ b/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
@@ -19,9 +19,9 @@ import TabItem from "@theme/TabItem";
 
     ### Installing manually
 
-    1. [Download](https://ziglang.org/download/#release-0.13.0) a prebuilt version of Zig.
+    1. [Download](https://ziglang.org/download/#release-0.14.0) a prebuilt version of Zig.
 
-        Choose a build of Zig 0.13 for Linux that matches your CPU architecture. If you're unsure which architecture you're using, this can be found with:
+        Choose a build of Zig 0.14 for Linux that matches your CPU architecture. If you're unsure which architecture you're using, this can be found with:
 
         ```bash
         uname -m
@@ -30,13 +30,13 @@ import TabItem from "@theme/TabItem";
     2. Extract the archive using tar, e.g.
 
         ```bash
-        tar xf zig-linux-x86_64-0.13.0.tar.xz
+        tar xf zig-linux-x86_64-0.14.0.tar.xz
         ```
 
     3. Add the location of your Zig binary to your path, e.g.
 
         ```bash
-        echo 'export PATH="$HOME/zig-linux-x86_64-0.13.0:$PATH"' >> ~/.bashrc
+        echo 'export PATH="$HOME/zig-linux-x86_64-0.14.0:$PATH"' >> ~/.bashrc
         ```
     </TabItem>
     <TabItem value="windows">
@@ -56,9 +56,9 @@ import TabItem from "@theme/TabItem";
 
     ### Installing manually
 
-    1. [Download](https://ziglang.org/download/#release-0.13.0) a prebuilt version of Zig.
+    1. [Download](https://ziglang.org/download/#release-0.14.0) a prebuilt version of Zig.
 
-        Choose a build of Zig 0.13 for Windows that matches your CPU architecture. Most Windows systems use `x86_64`, also known as `AMD64`. If you're unsure which architecture you're using, this can be found with:
+        Choose a build of Zig 0.14 for Windows that matches your CPU architecture. Most Windows systems use `x86_64`, also known as `AMD64`. If you're unsure which architecture you're using, this can be found with:
 
         ```powershell
         $Env:PROCESSOR_ARCHITECTURE
@@ -118,7 +118,7 @@ Verify your installation with `zig version`. The output should look like this:
 
 ```
 $ zig version
-0.13.0
+0.14.0
 ```
 
 ### Extras

--- a/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
+++ b/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
@@ -19,9 +19,9 @@ import TabItem from "@theme/TabItem";
 
     ### Installing manually
 
-    1. [Download](https://ziglang.org/download/#release-0.12.0) a prebuilt version of Zig.
+    1. [Download](https://ziglang.org/download/#release-0.13.0) a prebuilt version of Zig.
 
-        Choose a build of Zig 0.12 for Linux that matches your CPU architecture. If you're unsure which architecture you're using, this can be found with:
+        Choose a build of Zig 0.13 for Linux that matches your CPU architecture. If you're unsure which architecture you're using, this can be found with:
 
         ```bash
         uname -m
@@ -30,13 +30,13 @@ import TabItem from "@theme/TabItem";
     2. Extract the archive using tar, e.g.
 
         ```bash
-        tar xf zig-linux-x86_64-0.12.0.tar.xz
+        tar xf zig-linux-x86_64-0.13.0.tar.xz
         ```
 
     3. Add the location of your Zig binary to your path, e.g.
 
         ```bash
-        echo 'export PATH="$HOME/zig-linux-x86_64-0.12.0:$PATH"' >> ~/.bashrc
+        echo 'export PATH="$HOME/zig-linux-x86_64-0.13.0:$PATH"' >> ~/.bashrc
         ```
     </TabItem>
     <TabItem value="windows">
@@ -56,9 +56,9 @@ import TabItem from "@theme/TabItem";
 
     ### Installing manually
 
-    1. [Download](https://ziglang.org/download/#release-0.12.0) a prebuilt version of Zig.
+    1. [Download](https://ziglang.org/download/#release-0.13.0) a prebuilt version of Zig.
 
-        Choose a build of Zig 0.12 for Windows that matches your CPU architecture. Most Windows systems use `x86_64`, also known as `AMD64`. If you're unsure which architecture you're using, this can be found with:
+        Choose a build of Zig 0.13 for Windows that matches your CPU architecture. Most Windows systems use `x86_64`, also known as `AMD64`. If you're unsure which architecture you're using, this can be found with:
 
         ```powershell
         $Env:PROCESSOR_ARCHITECTURE
@@ -118,7 +118,7 @@ Verify your installation with `zig version`. The output should look like this:
 
 ```
 $ zig version
-0.12.0
+0.13.0
 ```
 
 ### Extras

--- a/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
+++ b/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
@@ -15,7 +15,9 @@ import TabItem from "@theme/TabItem";
         {label: 'macOS', value: 'macos'},
     ]}>
     <TabItem value="linux">
-<!--    Consider getting Zig from your distribution's [package manager](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager). Most major linux distros package the latest Zig release. -->
+{/*
+Consider getting Zig from your distribution's [package manager](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager). Most major linux distros package the latest Zig release.
+*/}
 
     ### Installing manually
 
@@ -40,7 +42,7 @@ import TabItem from "@theme/TabItem";
         ```
     </TabItem>
     <TabItem value="windows">
-<!--
+{/*
     Consider getting Zig from a package manager such as [chocolatey](https://chocolatey.org/), [scoop](https://scoop.sh/), or [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget).
 
     All commands shown are to be used inside Powershell.
@@ -54,7 +56,7 @@ import TabItem from "@theme/TabItem";
     ```
     scoop install zig
     ```
--->
+*/}
     Latest [dev build](https://scoop.sh/#/apps?q=zig&id=921df07e75042de645204262e784a17c2421944c) is available on [scoop](https://scoop.sh/#/apps?q=zig&id=7e124d6047c32d426e4143ab395d863fc9d6d491).
 
     ```
@@ -111,13 +113,13 @@ import TabItem from "@theme/TabItem";
     </TabItem>
 
     <TabItem value="macos">
-<!--
+{/*
     Consider getting Zig from a package manager such as [brew](https://brew.sh/).
 
     ```
     brew install zig
     ```
--->
+*/}
     </TabItem>
 
 </Tabs>

--- a/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
+++ b/website/versioned_docs/version-0.14/00-getting-started/02-installation.mdx
@@ -15,7 +15,7 @@ import TabItem from "@theme/TabItem";
         {label: 'macOS', value: 'macos'},
     ]}>
     <TabItem value="linux">
-    Consider getting Zig from your distribution's [package manager](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager). Most major linux distros package the latest Zig release.
+<!--    Consider getting Zig from your distribution's [package manager](https://github.com/ziglang/zig/wiki/Install-Zig-from-a-Package-Manager). Most major linux distros package the latest Zig release. -->
 
     ### Installing manually
 
@@ -30,16 +30,17 @@ import TabItem from "@theme/TabItem";
     2. Extract the archive using tar, e.g.
 
         ```bash
-        tar xf zig-linux-x86_64-0.14.0.tar.xz
+        tar xf zig-linux-x86_64-0.14.0-dev.2183+ee9f00d67.tar.xz
         ```
 
     3. Add the location of your Zig binary to your path, e.g.
 
         ```bash
-        echo 'export PATH="$HOME/zig-linux-x86_64-0.14.0:$PATH"' >> ~/.bashrc
+        echo 'export PATH="$HOME/zig-linux-x86_64-0.14.0-dev.2183+ee9f00d67:$PATH"' >> ~/.bashrc
         ```
     </TabItem>
     <TabItem value="windows">
+<!--
     Consider getting Zig from a package manager such as [chocolatey](https://chocolatey.org/), [scoop](https://scoop.sh/), or [winget](https://learn.microsoft.com/en-us/windows/package-manager/winget/#install-winget).
 
     All commands shown are to be used inside Powershell.
@@ -52,6 +53,13 @@ import TabItem from "@theme/TabItem";
     ```
     ```
     scoop install zig
+    ```
+-->
+    Latest [dev build](https://scoop.sh/#/apps?q=zig&id=921df07e75042de645204262e784a17c2421944c) is available on [scoop](https://scoop.sh/#/apps?q=zig&id=7e124d6047c32d426e4143ab395d863fc9d6d491).
+
+    ```
+    scoop bucket add versions
+    scoop install versions/zig-dev
     ```
 
     ### Installing manually
@@ -103,11 +111,13 @@ import TabItem from "@theme/TabItem";
     </TabItem>
 
     <TabItem value="macos">
+<!--
     Consider getting Zig from a package manager such as [brew](https://brew.sh/).
 
     ```
     brew install zig
     ```
+-->
     </TabItem>
 
 </Tabs>
@@ -118,7 +128,7 @@ Verify your installation with `zig version`. The output should look like this:
 
 ```
 $ zig version
-0.14.0
+0.14.0-dev.2183+ee9f00d67
 ```
 
 ### Extras


### PR DESCRIPTION
Resolve: #271

Fix the page for installing Zig 0.13.0. (https://zig.guide/getting-started/installation)

I have replaced all instances of 0.12.0 with 0.13.0.