### PR TITLE
Remove test summary from 'If Expressions' page.

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/03-if.mdx
@@ -8,13 +8,6 @@ import IfExpression from "!!raw-loader!./03.if-expression.zig";
 Zig's if statements accept `bool` values (i.e. `true` or `false`). Unlike languages
 like C or Javascript, there are no values that implicitly coerce to bool values.
 
-Here, we will introduce testing. Save the below code and compile + run it with
-`zig test file-name.zig`. We will be using the
-[`expect`](https://ziglang.org/documentation/master/std/#std.testing.expect)
-function from the standard library, which will cause the test to fail if it's
-given the value `false`. When a test fails, the error and stack trace will be
-shown.
-
 <CodeBlock language="zig">{Expect}</CodeBlock>
 
 If statements also work as expressions.

--- a/website/versioned_docs/version-0.14/01-language-basics/03-if.mdx
+++ b/website/versioned_docs/version-0.14/01-language-basics/03-if.mdx
@@ -8,13 +8,6 @@ import IfExpression from "!!raw-loader!./03.if-expression.zig";
 Zig's if statements accept `bool` values (i.e. `true` or `false`). Unlike languages
 like C or Javascript, there are no values that implicitly coerce to bool values.
 
-Here, we will introduce testing. Save the below code and compile + run it with
-`zig test file-name.zig`. We will be using the
-[`expect`](https://ziglang.org/documentation/master/std/#std.testing.expect)
-function from the standard library, which will cause the test to fail if it's
-given the value `false`. When a test fails, the error and stack trace will be
-shown.
-
 <CodeBlock language="zig">{Expect}</CodeBlock>
 
 If statements also work as expressions.


### PR DESCRIPTION
Since there is a dedicated page on running tests (https://zig.guide/getting-started/running-tests), the if expressions page doesn't need to "introduce testing".