### PR TITLE
Changed deprecated default initialization of GeneralPurposeAllocator

### DIFF
--- a/website/versioned_docs/version-0.13/02-standard-library/01.allocators-gpa.zig
+++ b/website/versioned_docs/version-0.13/02-standard-library/01.allocators-gpa.zig
@@ -4,7 +4,7 @@ const expect = std.testing.expect;
 
 // hide-end
 test "GPA" {
-    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
+    var gpa = std.heap.GeneralPurposeAllocator(.{}).init;
     const allocator = gpa.allocator();
     defer {
         const deinit_status = gpa.deinit();


### PR DESCRIPTION
Re: https://ziglang.org/documentation/master/std/#src/std/heap/general_purpose_allocator.zig

Default initialization of GeneralPurposeAllocator is deprecated; use `.init` instead.