### PR TITLE
say "defer is executed upon exiting block" in Update 07-defer.mdx

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/07-defer.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/07-defer.mdx
@@ -5,7 +5,7 @@ import DeferMulti from "!!raw-loader!./07.defer-multi.zig";
 
 # Defer
 
-Defer is used to execute a statement while exiting the current block.
+Defer is used to execute a statement upon exiting the current block.
 
 <CodeBlock language="zig">{Defer}</CodeBlock>
 


### PR DESCRIPTION
probably upon is more intuitive than while here. I don't know zig enough to say that "after" would be even better.