### PR TITLE
Fix code snippet to discard a pointer in "naughty pointer"

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
@@ -19,7 +19,7 @@ test "naughty pointer" {
     var x: u16 = 5;
     x -= 5;
     var y: *u8 = @ptrFromInt(x);
-    _ = &y;
+    y = y;
 }
 ```
 

--- a/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
@@ -16,9 +16,10 @@ Trying to set a `*T` to the value 0 is detectable illegal behaviour.
 
 ```zig
 test "naughty pointer" {
-    var x: u16 = 0;
+    var x: u16 = 5;
+    x -= 5;
     var y: *u8 = @ptrFromInt(x);
-    _ = y;
+    _ = &y;
 }
 ```
 

--- a/website/versioned_docs/version-0.14/01-language-basics/11-pointers.mdx
+++ b/website/versioned_docs/version-0.14/01-language-basics/11-pointers.mdx
@@ -19,7 +19,7 @@ test "naughty pointer" {
     var x: u16 = 5;
     x -= 5;
     var y: *u8 = @ptrFromInt(x);
-    _ = &y;
+    y = y;
 }
 ```
 

--- a/website/versioned_docs/version-0.14/01-language-basics/11-pointers.mdx
+++ b/website/versioned_docs/version-0.14/01-language-basics/11-pointers.mdx
@@ -16,9 +16,10 @@ Trying to set a `*T` to the value 0 is detectable illegal behaviour.
 
 ```zig
 test "naughty pointer" {
-    var x: u16 = 0;
+    var x: u16 = 5;
+    x -= 5;
     var y: *u8 = @ptrFromInt(x);
-    _ = y;
+    _ = &y;
 }
 ```
 


### PR DESCRIPTION
# Description

Fix guide for versions 0.14 & 0.13

Fix typo in code snippet. Discarding the variable should be `_ = &y;` instead of `_ = y;`.

Replace `var x: u16 = 0;` with `var x: u16 = 5; x -= 5;`. Else the compiler complains with `error: local variable is never mutated`. The updated example also highlights that the compiler is able to detect the value of x is not 0 after a mutation.

Note that `const x: u16 = 0` would have resulted in a different error message instead of `panic: cast causes pointer to be null`. 

resolves: https://github.com/Sobeston/zig.guide/issues/275