### PR TITLE
need mutation to display the desired error

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/11-pointers.mdx
@@ -38,6 +38,7 @@ test "const pointers" {
     const x: u8 = 1;
     var y = &x;
     y.* += 1;
+    y = y;
 }
 ```
 


### PR DESCRIPTION
without mutating `y`, instead of showing the `error: cannot assign to constant` error, you will get `error: local variable is never mutated note: consider using 'const'`