### PR TITLE
mutation required for the slices 3 example to work

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/14-slices.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/14-slices.mdx
@@ -54,7 +54,7 @@ The syntax `x[n..]` can also be used when you want to slice to the end.
 test "slices 3" {
     var array = [_]u8{ 1, 2, 3, 4, 5 };
     var slice = array[0..];
-    _ = slice;
+    slice = slice;
 }
 ```
 


### PR DESCRIPTION
the slices 3 example does not mutate `slice` but defines it via `var`