### PR TITLE
fix dreference entry for *[N]T

### DIFF
--- a/website/versioned_docs/version-0.13/01-language-basics/14-slices.mdx
+++ b/website/versioned_docs/version-0.13/01-language-basics/14-slices.mdx
@@ -62,7 +62,7 @@ Let's again compare our pointer types.
 
 | Feature         | `*T`              | `*[N]T`            | `[*]T`                           | `[]T`               |
 | --------------- | ----------------- | ------------------ | -------------------------------- | ------------------- |
-| Dereferenceable | Yes, e.g. `ptr.*` | No                 | No                               | No                  |
+| Dereferenceable | Yes, e.g. `ptr.*` | Yes                 | No                               | No                  |
 | Indexable       | No                | Yes                | Yes                              | Yes                 |
 | Sliceable       | No                | Yes                | Yes                              | Yes                 |
 | Element Count   | Always 1          | Compile-time known | Unknown                          | Runtime known       |

--- a/website/versioned_docs/version-0.14/01-language-basics/14-slices.mdx
+++ b/website/versioned_docs/version-0.14/01-language-basics/14-slices.mdx
@@ -62,7 +62,7 @@ Let's again compare our pointer types.
 
 | Feature         | `*T`              | `*[N]T`            | `[*]T`                           | `[]T`               |
 | --------------- | ----------------- | ------------------ | -------------------------------- | ------------------- |
-| Dereferenceable | Yes, e.g. `ptr.*` | No                 | No                               | No                  |
+| Dereferenceable | Yes, e.g. `ptr.*` | Yes                 | No                               | No                  |
 | Indexable       | No                | Yes                | Yes                              | Yes                 |
 | Sliceable       | No                | Yes                | Yes                              | Yes                 |
 | Element Count   | Always 1          | Compile-time known | Unknown                          | Runtime known       |


### PR DESCRIPTION
`*[N]T` can be dereferenced. Example :

```
test "dereferencing *[N]T works" {
    var arr: [3]u8 = .{ 1, 2, 3 };
    const ptr: *[3]u8 = &arr; // const, since we never reassign ptr

    // Dereference to get a copy
    const copy: [3]u8 = ptr.*;
    try std.testing.expectEqual(@as(u8, 1), copy[0]);
    try std.testing.expectEqual(@as(u8, 2), copy[1]);
    try std.testing.expectEqual(@as(u8, 3), copy[2]);

    // Mutate through pointer
    ptr[1] = 42;
    ptr.*[0] = 0;
    try std.testing.expectEqual(@as(u8, 42), arr[1]);
    try std.testing.expectEqual(@as(u8, 0), arr[0]);
}
```