### PR TITLE
Fix call to `addExecutable` in the `Zig Build` section

### DIFF
--- a/website/versioned_docs/version-0.15.x/03-build-system/04-zig-build.mdx
+++ b/website/versioned_docs/version-0.15.x/03-build-system/04-zig-build.mdx
@@ -107,7 +107,6 @@ that changes the executable's name.
             .target = b.standardTargetOptions(.{}),
             .optimize = b.standardOptimizeOption(.{}),
         }),
-
     });
 ```
 

--- a/website/versioned_docs/version-0.15.x/03-build-system/04-zig-build.mdx
+++ b/website/versioned_docs/version-0.15.x/03-build-system/04-zig-build.mdx
@@ -102,9 +102,12 @@ that changes the executable's name.
 
     const exe = b.addExecutable(.{
         .name = exe_name,
-        .root_source_file = b.path("src/main.zig"),
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = b.standardTargetOptions(.{}),
+            .optimize = b.standardOptimizeOption(.{}),
+        }),
+
     });
 ```
 

--- a/website/versioned_docs/version-0.15.x/03-build-system/04.zig-build-hello/build.zig
+++ b/website/versioned_docs/version-0.15.x/03-build-system/04.zig-build-hello/build.zig
@@ -3,9 +3,11 @@ const std = @import("std");
 pub fn build(b: *std.Build) void {
     const exe = b.addExecutable(.{
         .name = "hello",
-        .root_source_file = b.path("src/main.zig"),
-        .target = b.standardTargetOptions(.{}),
-        .optimize = b.standardOptimizeOption(.{}),
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/main.zig"),
+            .target = b.standardTargetOptions(.{},
+            .optimize = b.standardOptimizeOption(.{}),
+        }),
     });
 
     b.installArtifact(exe);

--- a/website/versioned_docs/version-0.15.x/03-build-system/04.zig-build-hello/build.zig
+++ b/website/versioned_docs/version-0.15.x/03-build-system/04.zig-build-hello/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
         .name = "hello",
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/main.zig"),
-            .target = b.standardTargetOptions(.{},
+            .target = b.standardTargetOptions(.{}),
             .optimize = b.standardOptimizeOption(.{}),
         }),
     });


### PR DESCRIPTION
Today I started to learn zig for a side project that I'm planning, and was going through the tutorial when I got stuck at `Zig Build`. The function definition of `b.addExecutable` was different from the one I had locally. I've verified that I'm on zig version `0.15.2` and the doc I was following had the tag `Version: Zig 0.15.2` at the top as well. I've managed to get it working based on the docs found in https://ziglang.org/learn/build-system/

Running `zig build --summary all` locally passes on the modified branch.