### PR TITLE
Improve error union demo code

### DIFF
--- a/website/versioned_docs/version-0.15.x/01-language-basics/08.error-union.zig
+++ b/website/versioned_docs/version-0.15.x/01-language-basics/08.error-union.zig
@@ -13,6 +13,5 @@ test "error union" {
     const maybe_error: AllocationError!u16 = AllocationError.OutOfMemory;
     const no_error = maybe_error catch 0;
 
-    try expect(@TypeOf(no_error) == u16);
     try expect(no_error == 0);
 }

--- a/website/versioned_docs/version-0.15.x/01-language-basics/08.error-union.zig
+++ b/website/versioned_docs/version-0.15.x/01-language-basics/08.error-union.zig
@@ -10,9 +10,9 @@ const AllocationError = error{OutOfMemory};
 
 // hide-end
 test "error union" {
-    const maybe_error: AllocationError!u16 = 10;
+    const maybe_error: AllocationError!u16 = AllocationError.OutOfMemory;
     const no_error = maybe_error catch 0;
 
     try expect(@TypeOf(no_error) == u16);
-    try expect(no_error == 10);
+    try expect(no_error == 0);
 }


### PR DESCRIPTION
## Description

The code in the current error union demo code, named `maybe_error` would never actually error. This change improves on the demonstration of how `catch` works by actually using it.

## Changes

Sets the `maybe_error` to be of value `AllocationError.OutOfMemory` which means the value of `no_error` would use the `catch`, displaying the way that catch is used in Zig with an error union.
