### PR TITLE
replace getStdOut() with OS write syscalls

### DIFF
--- a/website/versioned_docs/version-0.15.x/03-build-system/02-emitting-an-executable.md
+++ b/website/versioned_docs/version-0.15.x/03-build-system/02-emitting-an-executable.md
@@ -37,6 +37,6 @@ const std = @import("std");
 pub fn main() void {
     const msg = "Hello World\n";
     const handle = std.os.windows.GetStdHandle(std.os.windows.STD_OUTPUT_HANDLE) catch return;
-    _ = std.os.windows.WriteFile(handle, msg, null, null) catch return;
+    _ = std.os.windows.WriteFile(handle, msg, null) catch return;
 }
 ```

--- a/website/versioned_docs/version-0.15.x/03-build-system/02-emitting-an-executable.md
+++ b/website/versioned_docs/version-0.15.x/03-build-system/02-emitting-an-executable.md
@@ -15,12 +15,28 @@ Some common arguments:
 Let's create a tiny hello world. Save this as `tiny-hello.zig`, and run
 `zig build-exe tiny-hello.zig -O ReleaseSmall -fstrip -fsingle-threaded`.
 
+We'll print "Hello World" using Zig's wrappers around the OS write syscall
+
+Linux:
+
 ```zig
 const std = @import("std");
 
 pub fn main() void {
-    std.io.getStdOut().writeAll(
-        "Hello World!",
-    ) catch unreachable;
+    const msg = "Hello World\n";
+    _ = std.os.linux.write(1, msg, msg.len);
+}
+
+```
+
+Windows:
+
+```zig
+const std = @import("std");
+
+pub fn main() void {
+    const msg = "Hello World\n";
+    const handle = std.os.windows.GetStdHandle(std.os.windows.STD_OUTPUT_HANDLE) catch return;
+    _ = std.os.windows.WriteFile(handle, msg, null, null) catch return;
 }
 ```


### PR DESCRIPTION
Hi Sobeston,
I just made an update to transition the deprecated `getStdOut` function from its dependence on io to using Zig's wrapper around the syscalls.

I've tested the code locally and it compiles, and I've gone through "CONTRIBUTING" on readme.md, but I did not find the test folder in the codebase to see how to improve that.

Please let me know if there's something you'd like me to improve.