### PR TITLE
Fix typo in slices documentation

### DIFF
--- a/website/versioned_docs/version-0.15.x/01-language-basics/14-slices.mdx
+++ b/website/versioned_docs/version-0.15.x/01-language-basics/14-slices.mdx
@@ -6,7 +6,7 @@ import Slices2 from "!!raw-loader!./14.slices-2.zig";
 # Slices
 
 Slices can be thought of many-item pointers (`[*]T`) with a length (`usize`).
-These use the syntax `[]T`. Slices are easier to use safely and more convinient
+These use the syntax `[]T`. Slices are easier to use safely and more convenient
 than many-item pointers, as they store the valid length of the buffer with them.
 Slices are sometimes referred to as "fat pointers" as they're typically double
 the size of a normal pointer. Slices are the most common way to pass around


### PR DESCRIPTION
Corrected a typo in the description of slices.