### PR TITLE
Clarify swtich type rules

### DIFF
--- a/website/versioned_docs/version-0.15.x/01-language-basics/09-switch.mdx
+++ b/website/versioned_docs/version-0.15.x/01-language-basics/09-switch.mdx
@@ -6,9 +6,9 @@ import SwitchExpression from "!!raw-loader!./09.switch-expression.zig";
 # Switch
 
 Zig's `switch` works as both a statement and an expression. The types of all
-branches must coerce to the type which is being switched upon. All possible
-values must have an associated branch - values cannot be left out. Cases cannot
-fall through to other branches.
+branches must coerce to the same type. All possible values must have an
+associated branch - values cannot be left out. Cases cannot fall through to
+other branches.
 
 An example of a switch statement. The else is required to satisfy the
 exhaustiveness of this switch.


### PR DESCRIPTION
Take the following example:
```zig
const x: u8 = 1;
switch (x) {
    1 => "hello",
    else => "world!",
};
```

To me, the "type which is being switched upon" sounds like the type of x, which is u8. The current text makes me think that the switch expression must also return a u8, which isn't the case.